### PR TITLE
Fix theme name mismatch

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {  
-   "name": "Purple Owl Theme",  
+   "name": "Purple Owl",  
    "version": "1.0.1",  
    "minAppVersion": "0.16.0",  
    "author": "zacharyc",  


### PR DESCRIPTION
When installing from Obsidian's community theme browser, it refuses to install due to a theme name mismatch. This PR changes manifest.json to make it work, due to it seeming simpler to edit the manifest than make a new PR on Obsidian's repo to fix the error.